### PR TITLE
Add Monocypher

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ List of potentially unsafe ed25519 signature libraries that allow a public api w
 
 Μost of the repositories in our analysis are enlisted in [IANIX :: Things that use Ed25519](https://ianix.com/pub/ed25519-deployment.html).
 
-Number of impacted libraries: 39 <br />
+Number of impacted libraries: 40 <br />
 Number of libraries that fixed the issue after the announcement: 2 <br />
 *last updated: June 30, 2022*
 
@@ -58,6 +58,9 @@ and
 
 * C: ed25519 (Orson Peters) <br />
 [https://github.com/orlp/ed25519/blob/master/src/sign.c#L7](https://github.com/orlp/ed25519/blob/master/src/sign.c#L7)
+
+* C: Monocypher (Loup Vaillant) <br />
+  [https://monocypher.org/manual/sign](https://monocypher.org/manual/sign)
 
 * C: libbrine (Kevin Smith) <br />
 [https://github.com/kevsmith/libbrine/blob/master/src/ed25519/sign.c#L7](https://github.com/kevsmith/libbrine/blob/master/src/ed25519/sign.c#L7)


### PR DESCRIPTION
Note: as the author of Monocypher, I can reasonably speculate this will
not be fixed.  I may provide a higher-level interface that doesn't
exhibit the problem, but the vulnerable API will likely not go away.

The main reason is because Monocypher is meant to be used many different
settings, included weak embedded machines where a single signature takes
up to a minute, and recomputing the public key on the fly is not an
option.  On the other hand, other users may wish to pack their data as
much as possible, and generate the public key on the fly to compensate.

Right now I don't see how I can satisfy both use cases without the
current API.  Strictly speaking even NaCl can do it, but few users are
wicked enough to conserve only the first 32 bytes of the private key and
rebuilding the public half right next to it on the fly.